### PR TITLE
stop sprite when user gives invalid path

### DIFF
--- a/path-following.ts
+++ b/path-following.ts
@@ -104,6 +104,8 @@ namespace scene {
                 for (let i = pathFollowingSprites.length - 1; i >= 0; i--) {
                     const pfs = pathFollowingSprites[i];
                     if (pfs.sprite === sprite) {
+                        sprite.vx = 0;
+                        sprite.vy = 0;
                         pathFollowingSprites.removeAt(i);
                     }
                 }


### PR DESCRIPTION
When the user is gives an invalid path, we should stop following any path the sprite currently is following (current behavior), **and** stop the sprites current velocity (this change) -- it feels very broken when they're on the last bit of a path and you stop their path right now, as they will continue with their current momentum and still run into the target